### PR TITLE
FIX: Minor readme file fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 An app to show dota2 related information using JetpackCompose.
 
-[heroes](https://user-images.githubusercontent.com/33685811/120830471-d1a85600-c55e-11eb-9f0b-9aef941eea68.png)
-[teams](https://user-images.githubusercontent.com/33685811/120830475-d240ec80-c55e-11eb-93c7-77d81263a045.png)
+[heroes](https://user-images.githubusercontent.com/33685811/120830475-d240ec80-c55e-11eb-93c7-77d81263a045.png)
+[teams](https://user-images.githubusercontent.com/33685811/120830471-d1a85600-c55e-11eb-9f0b-9aef941eea68.png)
+
 
 ### API
 


### PR DESCRIPTION
heroes and teams links were pointing to wrong endpoints. 
just fixed their reference links.