### PR TITLE
feat: Added PlayersRepository and playersByRank call

### DIFF
--- a/app/src/main/java/me/ilker/dota2compose/MainViewModel.kt
+++ b/app/src/main/java/me/ilker/dota2compose/MainViewModel.kt
@@ -19,12 +19,14 @@ import me.ilker.dota2compose.presenter.TeamState
 import me.ilker.dota2compose.presenter.TeamsState
 import javax.inject.Inject
 import me.ilker.dota2compose.repository.LeaguesRepository
+import me.ilker.dota2compose.repository.PlayersRepository
 import me.ilker.dota2compose.service.NetworkService
 
 @HiltViewModel
 class MainViewModel @Inject constructor(
     private val apiService: NetworkService,
-    private val leaguesRepository: LeaguesRepository
+    private val leaguesRepository: LeaguesRepository,
+    private val playersRepository: PlayersRepository
 ) : ViewModel() {
     private var subscription = Disposable.disposed()
 

--- a/app/src/main/java/me/ilker/dota2compose/di/NetworkModule.kt
+++ b/app/src/main/java/me/ilker/dota2compose/di/NetworkModule.kt
@@ -13,6 +13,7 @@ import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import javax.inject.Singleton
+import me.ilker.dota2compose.service.PlayersService
 
 @ExperimentalSerializationApi
 @Module
@@ -24,7 +25,7 @@ class NetworkModule {
 
     @Provides
     @Singleton
-    fun providesRetrofit(
+    fun providesNetworkService(
         okHttpClient: OkHttpClient
     ): NetworkService = Retrofit.Builder()
         .baseUrl("https://api.opendota.com/api/")
@@ -34,6 +35,19 @@ class NetworkModule {
         )
         .build()
         .create(NetworkService::class.java)
+    
+    @Provides
+    @Singleton
+    fun providesPlayersService(
+        okHttpClient: OkHttpClient
+    ): PlayersService = Retrofit.Builder()
+        .baseUrl("https://api.opendota.com/api/")
+        .client(okHttpClient)
+        .addConverterFactory(
+            json.asConverterFactory("application/json".toMediaType())
+        )
+        .build()
+        .create(PlayersService::class.java)
 
     @Provides
     @Singleton

--- a/app/src/main/java/me/ilker/dota2compose/di/RepositoryModule.kt
+++ b/app/src/main/java/me/ilker/dota2compose/di/RepositoryModule.kt
@@ -7,6 +7,8 @@ import dagger.hilt.android.components.ViewModelComponent
 import dagger.hilt.android.scopes.ViewModelScoped
 import me.ilker.dota2compose.repository.LeaguesRepository
 import me.ilker.dota2compose.repository.LeaguesRepositoryImpl
+import me.ilker.dota2compose.repository.PlayersRepository
+import me.ilker.dota2compose.repository.PlayersRepositoryImpl
 
 @Module
 @InstallIn(ViewModelComponent::class)
@@ -15,4 +17,8 @@ abstract class RepositoryModule {
     @Binds
     @ViewModelScoped
     abstract fun bindsLeaguesRepository(repositoryImpl: LeaguesRepositoryImpl): LeaguesRepository
+    
+    @Binds
+    @ViewModelScoped
+    abstract fun bindsPlayersRepository(repositoryImpl: PlayersRepositoryImpl): PlayersRepository
 }

--- a/app/src/main/java/me/ilker/dota2compose/model/network/response/PlayerByRankResponse.kt
+++ b/app/src/main/java/me/ilker/dota2compose/model/network/response/PlayerByRankResponse.kt
@@ -1,0 +1,9 @@
+package me.ilker.dota2compose.model.network.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PlayerByRankResponse(
+    @SerialName("account_id") val accountID: Long? = null
+)

--- a/app/src/main/java/me/ilker/dota2compose/model/network/response/TeamPlayerResponse.kt
+++ b/app/src/main/java/me/ilker/dota2compose/model/network/response/TeamPlayerResponse.kt
@@ -1,9 +1,10 @@
 package me.ilker.dota2compose.model.network.response
 
 import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 import me.ilker.dota2compose.model.domain.TeamPlayer
 
-@kotlinx.serialization.Serializable
+@Serializable
 data class TeamPlayerResponse(
     @SerialName("account_id") val accountID: Long? = null,
     @SerialName("name") val name: String? = null,

--- a/app/src/main/java/me/ilker/dota2compose/repository/PlayersRepository.kt
+++ b/app/src/main/java/me/ilker/dota2compose/repository/PlayersRepository.kt
@@ -1,0 +1,7 @@
+package me.ilker.dota2compose.repository
+
+import me.ilker.dota2compose.model.network.response.PlayerByRankResponse
+
+interface PlayersRepository {
+    suspend fun getPlayersByRank(): List<PlayerByRankResponse>
+}

--- a/app/src/main/java/me/ilker/dota2compose/repository/PlayersRepositoryImpl.kt
+++ b/app/src/main/java/me/ilker/dota2compose/repository/PlayersRepositoryImpl.kt
@@ -1,0 +1,12 @@
+package me.ilker.dota2compose.repository
+
+import javax.inject.Inject
+import me.ilker.dota2compose.model.network.response.PlayerByRankResponse
+import me.ilker.dota2compose.service.PlayersService
+
+class PlayersRepositoryImpl @Inject constructor(
+    private val playersService: PlayersService
+) : PlayersRepository {
+    override suspend fun getPlayersByRank(): List<PlayerByRankResponse> =
+        playersService.getPlayersByRank()
+}

--- a/app/src/main/java/me/ilker/dota2compose/service/PlayersService.kt
+++ b/app/src/main/java/me/ilker/dota2compose/service/PlayersService.kt
@@ -1,0 +1,10 @@
+package me.ilker.dota2compose.service
+
+import me.ilker.dota2compose.model.network.response.PlayerByRankResponse
+import retrofit2.http.GET
+
+interface PlayersService {
+    
+    @GET("playersByRank")
+    suspend fun getPlayersByRank(): List<PlayerByRankResponse>
+}


### PR DESCRIPTION
In this PR, I have - 

1. Added a `PlayersService` for the API call interface. Updated the DI setup accordingly.
1. Added `PlayersRepository` & the implementation of `playersByRank` method.

In a future issue/PR, it will be nice to consider and implement a cleaner separation of the Service/Repositories setup.

Closes #4 