### PR TITLE
Added Player model and GET PlayerByAccountId

### DIFF
--- a/app/src/main/java/me/ilker/dota2compose/model/domain/Player.kt
+++ b/app/src/main/java/me/ilker/dota2compose/model/domain/Player.kt
@@ -1,0 +1,31 @@
+package me.ilker.dota2compose.model.domain
+
+data class MmrEstimate(
+    val estimate: Int? = null
+)
+
+data class Profile(
+    val accountId: Int? = null,
+    val personaName: String? = null,
+    val name: String? = null,
+    val plus: Boolean? = null,
+    val cheese: Int? = null,
+    val steamId: String? = null,
+    val avatar: String? = null,
+    val avatarMedium: String? = null,
+    val avatarFull: String? = null,
+    val profileUrl: String? = null,
+    val lastLogin: String? = null,
+    val locCountryCode: String? = null,
+    val isContributor: Boolean? = null,
+    val isSubscriber: Boolean? = null,
+)
+
+data class Player(
+    val soloCompetitiveRank: Int? = null,
+    val competitiveRank: Int? = null,
+    val rankTier: Int? = null,
+    val leaderboardRank: Int? = null,
+    val mmrEstimate: MmrEstimate? = null,
+    val profile: Profile? = null
+)

--- a/app/src/main/java/me/ilker/dota2compose/model/network/response/PlayerResponse.kt
+++ b/app/src/main/java/me/ilker/dota2compose/model/network/response/PlayerResponse.kt
@@ -1,0 +1,70 @@
+package me.ilker.dota2compose.model.network.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import me.ilker.dota2compose.model.domain.MmrEstimate
+import me.ilker.dota2compose.model.domain.Player
+import me.ilker.dota2compose.model.domain.Profile
+
+@Serializable
+data class MmrEstimateResponse(
+    @SerialName("estimate") val estimate: Int? = null
+) {
+    fun toDomain(): MmrEstimate = MmrEstimate(
+        estimate = estimate
+    )
+}
+
+@Serializable
+data class ProfileResponse(
+    @SerialName("account_id") val accountId: Int? = null,
+    @SerialName("personaname") val personaName: String? = null,
+    @SerialName("name") val name: String? = null,
+    @SerialName("plus") val plus: Boolean? = null,
+    @SerialName("cheese") val cheese: Int? = null,
+    @SerialName("steamid") val steamId: String? = null,
+    @SerialName("avatar") val avatar: String? = null,
+    @SerialName("avatarmedium") val avatarMedium: String? = null,
+    @SerialName("avatarfull") val avatarFull: String? = null,
+    @SerialName("profileurl") val profileUrl: String? = null,
+    @SerialName("last_login") val lastLogin: String? = null,
+    @SerialName("loccountrycode") val locCountryCode: String? = null,
+    @SerialName("is_contributor") val isContributor: Boolean? = null,
+    @SerialName("is_subscriber") val isSubscriber: Boolean? = null,
+) {
+    fun toDomain(): Profile = Profile(
+        accountId = accountId,
+        personaName = personaName,
+        name = name,
+        plus = plus,
+        cheese = cheese,
+        steamId = steamId,
+        avatar = avatar,
+        avatarMedium = avatarMedium,
+        avatarFull = avatarFull,
+        profileUrl = profileUrl,
+        lastLogin = lastLogin,
+        locCountryCode = locCountryCode,
+        isContributor = isContributor,
+        isSubscriber = isSubscriber,
+    )
+}
+
+@Serializable
+data class PlayerResponse(
+    @SerialName("solo_competitive_rank") val soloCompetitiveRank: Int? = null,
+    @SerialName("competitive_rank") val competitiveRank: Int? = null,
+    @SerialName("rank_tier") val rankTier: Int? = null,
+    @SerialName("leaderboard_rank") val leaderboardRank: Int? = null,
+    @SerialName("mmr_estimate") val mmrEstimate: MmrEstimateResponse? = null,
+    @SerialName("profile") val profile: ProfileResponse? = null
+) {
+    fun toDomain(): Player = Player(
+        soloCompetitiveRank = soloCompetitiveRank,
+        competitiveRank = competitiveRank,
+        rankTier = rankTier,
+        leaderboardRank = leaderboardRank,
+        mmrEstimate = mmrEstimate?.toDomain(),
+        profile = profile?.toDomain()
+    )
+}

--- a/app/src/main/java/me/ilker/dota2compose/repository/PlayersRepository.kt
+++ b/app/src/main/java/me/ilker/dota2compose/repository/PlayersRepository.kt
@@ -1,0 +1,11 @@
+package me.ilker.dota2compose.repository
+
+import me.ilker.dota2compose.model.network.response.PlayerResponse
+
+interface PlayersRepository {
+
+    /**
+     * accountId is the Steam32 ID of the player
+     */
+    suspend fun getPlayerByAccountId(accountId: Int): PlayerResponse?
+}

--- a/app/src/main/java/me/ilker/dota2compose/repository/PlayersRepositoryImpl.kt
+++ b/app/src/main/java/me/ilker/dota2compose/repository/PlayersRepositoryImpl.kt
@@ -1,0 +1,11 @@
+package me.ilker.dota2compose.repository
+
+import me.ilker.dota2compose.model.network.response.PlayerResponse
+import me.ilker.dota2compose.service.PlayersService
+import javax.inject.Inject
+
+class PlayersRepositoryImpl @Inject constructor(private val playersService: PlayersService) : PlayersRepository {
+
+    override suspend fun getPlayerByAccountId(accountId: Int): PlayerResponse? =
+        playersService.getPlayerByAccountId(accountId)
+}

--- a/app/src/main/java/me/ilker/dota2compose/service/PlayersService.kt
+++ b/app/src/main/java/me/ilker/dota2compose/service/PlayersService.kt
@@ -1,0 +1,11 @@
+
+package me.ilker.dota2compose.service
+
+import me.ilker.dota2compose.model.network.response.PlayerResponse
+import retrofit2.http.GET
+
+interface PlayersService {
+
+    @GET("players/{accountId}")
+    suspend fun getPlayerByAccountId(accountId: Int): PlayerResponse?
+}


### PR DESCRIPTION
Added Player model and serializer with new GET PlayerByAccountId


- [ x ]  Have a method named playerByID() which makes an API call to [this endpoint](https://api.opendota.com/api/players/%7Baccount_id%7D).

- [ x ]  This method should return a a player if it has been found, otherwise null.

Closes #40 